### PR TITLE
UI improvements

### DIFF
--- a/components/ISPOCard.js
+++ b/components/ISPOCard.js
@@ -19,9 +19,9 @@ export default function ISPOCard(props) {
   return (
     <Card
       sx={{
-        width: '400px',
+        width: {xs: '370px', xl: '400px'},
         py: 2.5,
-        px: 3.5,
+        px: {xs: 2, xl: 3.5},
         display: 'flex',
         flexDirection: 'column',
       }}

--- a/components/ISPOCard.js
+++ b/components/ISPOCard.js
@@ -24,6 +24,7 @@ export default function ISPOCard(props) {
         px: {xs: 2, xl: 3.5},
         display: 'flex',
         flexDirection: 'column',
+        ...(props.sx && props.sx),
       }}
     >
       {props.name && (

--- a/layouts/CardGrid.js
+++ b/layouts/CardGrid.js
@@ -15,6 +15,7 @@ const CardGrid = ({children}) => {
         sx={{
           display: 'flex',
           flexWrap: 'wrap',
+          justifyContent: 'center',
           gap: '10px',
           pb: 4,
         }}

--- a/pages/participate/index.js
+++ b/pages/participate/index.js
@@ -35,6 +35,8 @@ export default function ParticipateIspoPage() {
     ispos &&
     [...ispos].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
   // sort ended at the and
+  // relies on the sort function being stable
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability
   const sortedIspos =
     sortedIsposByDate &&
     [...sortedIsposByDate].sort((a, b) =>

--- a/pages/participate/index.js
+++ b/pages/participate/index.js
@@ -12,26 +12,44 @@ import {
   Chip,
   Tooltip,
 } from '@mui/material'
+import EventBusyIcon from '@mui/icons-material/EventBusy'
 import ISPOCard, {IspoDetail} from '../../components/ISPOCard'
 import * as fcl from '@onflow/fcl'
 import delegateToISPO from '../../cadence/web/transactions/client/delegateToISPO.cdc'
 import {toUFixString, formatCompactAmount} from '../../helpers/utils'
 import useCurrentUser from '../../hooks/useCurrentUser'
 import CardGrid from '../../layouts/CardGrid'
-import { useCurrentEpoch } from '../../hooks/epochs'
+import {useCurrentEpoch} from '../../hooks/epochs'
 
 export default function ParticipateIspoPage() {
   const {addr} = useCurrentUser()
   const res = useAccountIspos(addr)
 
   const ispos = useIspos()
+  const currentEpoch = useCurrentEpoch()
 
+  const canJoin = (epochEnd) => Number(currentEpoch) < Number(epochEnd)
+
+  // sort by time of creation
+  const sortedIsposByDate =
+    ispos &&
+    [...ispos].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+  // sort ended at the and
+  const sortedIspos =
+    sortedIsposByDate &&
+    [...sortedIsposByDate].sort((a, b) =>
+      canJoin(a.epochEnd) && !canJoin(b.epochEnd) ? -1 : 1,
+    )
   return (
     <CardGrid>
-      {ispos?.map((ispo) => (
-        <ParticipateCard ispoData={ispo} key={ispo.id} />
+      {sortedIspos?.map((ispo) => (
+        <ParticipateCard
+          ispoData={ispo}
+          key={ispo.id}
+          disabled={!canJoin(ispo.epochEnd)}
+        />
       ))}
-      {ispos?.length === 0 && (
+      {sortedIspos?.length === 0 && (
         <Typography variant="h5" sx={{fontWeight: 'bold'}}>
           No offerings found
         </Typography>
@@ -40,14 +58,11 @@ export default function ParticipateIspoPage() {
   )
 }
 
-function ParticipateCard({ispoData}) {
+function ParticipateCard({ispoData, disabled = false}) {
   const [form, setForm] = useState({})
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [alertMsg, setAlert] = useState(null)
   const [successMsg, setSuccess] = useState(null)
-  const currentEpoch = useCurrentEpoch()
-
-  const canJoin = Number(currentEpoch) < Number(ispoData.epochEnd)
 
   const getRewardPerEpoch = (totalRewardBalance, epochStart, epochEnd) =>
     totalRewardBalance / (epochEnd - epochStart)
@@ -81,6 +96,7 @@ function ParticipateCard({ispoData}) {
 
   return (
     <ISPOCard
+      sx={{opacity: !disabled ? 1 : 0.6}}
       {...ispoData}
       key={ispoData.id}
       body={
@@ -142,44 +158,66 @@ function ParticipateCard({ispoData}) {
       }
       footerContent={
         <>
-          <Box
-            component="form"
-            display="flex"
-            gap={2}
-            justifyContent="space-between"
-            alignItems="flex-end"
-            mb={1}
-          >
-            <TextField
-              variant="standard"
-              name="lockedFlowAmount"
-              label="Amount $FLOW"
-              value={form.lockedFlowAmount || ''}
-              onChange={handleChange}
-            />
-            <Tooltip title={!canJoin ? "ISPO is not active" :  ''}>
-              <div>
+          {!disabled ? (
+            <>
+              <Box
+                component="form"
+                display="flex"
+                gap={2}
+                justifyContent="space-between"
+                alignItems="flex-end"
+                mb={1}
+              >
+                <TextField
+                  variant="standard"
+                  name="lockedFlowAmount"
+                  label="Amount $FLOW"
+                  value={form.lockedFlowAmount || ''}
+                  onChange={handleChange}
+                />
                 <Button
                   variant="gradient"
                   onClick={getOnSubmit(ispoData.id)}
                   sx={{width: 'fit-content'}}
-                  disabled={!canJoin}
                 >
                   Join ISPO
                 </Button>
-              </div>
-            </Tooltip>
-          </Box>
-          {successMsg && <Alert severity="success" onClose={() => setSuccess(null)}>{successMsg}</Alert>}
-          {alertMsg && <Alert severity="error" onClose={() => setAlert(null)}>{alertMsg}</Alert>}
-          <Portal>
-            <Backdrop
-              sx={{color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1}}
-              open={isSubmitting}
+              </Box>
+              {successMsg && (
+                <Alert severity="success" onClose={() => setSuccess(null)}>
+                  {successMsg}
+                </Alert>
+              )}
+              {alertMsg && (
+                <Alert severity="error" onClose={() => setAlert(null)}>
+                  {alertMsg}
+                </Alert>
+              )}
+              <Portal>
+                <Backdrop
+                  sx={{
+                    color: '#fff',
+                    zIndex: (theme) => theme.zIndex.drawer + 1,
+                  }}
+                  open={isSubmitting}
+                >
+                  <CircularProgress color="inherit" />
+                </Backdrop>
+              </Portal>
+            </>
+          ) : (
+            <Alert
+              variant="outlined"
+              icon={<EventBusyIcon color="disabled" />}
+              sx={({palette}) => ({
+                color: palette.text.disabled,
+                borderColor: palette.divider,
+              })}
+              color=""
             >
-              <CircularProgress color="inherit" />
-            </Backdrop>
-          </Portal>
+              The last ISPO epoch already ended
+            </Alert>
+          )}
         </>
       }
     />


### PR DESCRIPTION
- fix layout for mac screens
before (ignore changes from second commit)
![image](https://user-images.githubusercontent.com/64598949/221565816-5f390db2-e7f5-4d4e-ba9e-0264655ba4d9.png)
after (ignore changes from second commit)
![image](https://user-images.githubusercontent.com/64598949/221564904-4812f729-e851-4a62-b9b5-4456da272d2b.png)

- sort participation offerings by date and visually distinguish ended 
![image](https://user-images.githubusercontent.com/64598949/221564798-dfa21c1a-0905-4b37-8bd4-819510a58378.png)
